### PR TITLE
Update of setenv scripts to avoid CATALINA_PID overriding & Xms equal Xmx & adding comments

### DIFF
--- a/deploy/distrib/src/main/resources/tomcat/bin/setenv.bat
+++ b/deploy/distrib/src/main/resources/tomcat/bin/setenv.bat
@@ -1,11 +1,20 @@
 @echo on
 
-rem Sets some variables
+rem Set some JVM system properties required by Bonita BPM
+
+rem Bonita home folder (configuration files, temporary folder...) location
 set BONITA_HOME="-Dbonita.home=%CATALINA_HOME%\bonita"
+
+rem Define the RDMBS vendor use by Bonita Engine to store data
 set DB_OPTS="-Dsysprop.bonita.db.vendor=h2"
+
+rem Bitronix (JTA service added to Tomcat and required by Bonita Engine for transaction management)
 set BTM_OPTS="-Dbtm.root=%CATALINA_HOME%" "-Dbitronix.tm.configuration=%CATALINA_HOME%\conf\bitronix-config.properties"
+
+rem Optionnal JAAS configuration. Usually used when delgating authentication to LDAP / Active Directory server
 rem set SECURITY_OPTS="-Djava.security.auth.login.config=%CATALINA_HOME%\conf\jaas-standard.cfg"
 
-set CATALINA_OPTS=%CATALINA_OPTS% %BONITA_HOME% %DB_OPTS% %BTM_OPTS% -Dfile.encoding=UTF-8 -Xshare:auto -Xms512m -Xmx1024m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError
+rem Pass the JVM system properties to Tomcat JVM using CATALINA_OPTS variable
+set CATALINA_OPTS=%CATALINA_OPTS% %BONITA_HOME% %DB_OPTS% %BTM_OPTS% -Dfile.encoding=UTF-8 -Xshare:auto -Xms1024m -Xmx1024m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError
 
 set CATALINA_PID=%CATALINA_BASE%\catalina.pid

--- a/deploy/distrib/src/main/resources/tomcat/bin/setenv.sh
+++ b/deploy/distrib/src/main/resources/tomcat/bin/setenv.sh
@@ -1,14 +1,25 @@
 #!/bin/sh
 
-# Sets some variables
+# Set some JVM system properties required by Bonita BPM
+
+# Bonita home folder (configuration files, temporary folder...) location
 BONITA_HOME="-Dbonita.home=${CATALINA_HOME}/bonita"
+
+# Define the RDMBS vendor use by Bonita Engine to store data
 DB_OPTS="-Dsysprop.bonita.db.vendor=h2"
+
+# Bitronix (JTA service added to Tomcat and required by Bonita Engine for transaction management)
 BTM_OPTS="-Dbtm.root=${CATALINA_HOME} -Dbitronix.tm.configuration=${CATALINA_HOME}/conf/bitronix-config.properties"
+
+# Optionnal JAAS configuration. Usually used when delgating authentication to LDAP / Active Directory server
 #SECURITY_OPTS="-Djava.security.auth.login.config=${CATALINA_HOME}/conf/jaas-standard.cfg"
 
-
-CATALINA_OPTS="${CATALINA_OPTS} ${BONITA_HOME} ${DB_OPTS} ${BTM_OPTS} -Dfile.encoding=UTF-8 -Xshare:auto -Xms512m -Xmx1024m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError"
+# Pass the JVM system properties to Tomcat JVM using CATALINA_OPTS variable
+CATALINA_OPTS="${CATALINA_OPTS} ${BONITA_HOME} ${DB_OPTS} ${BTM_OPTS} -Dfile.encoding=UTF-8 -Xshare:auto -Xms1024m -Xmx1024m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError"
 export CATALINA_OPTS
 
-CATALINA_PID=${CATALINA_BASE}/catalina.pid
-export CATALINA_PID
+# Only set CATALINA_PID if not already set (check for empty value) by startup script (usually done by /etc/init.d/tomcat7 but not by startup.sh nor catalina.sh)
+if [ -z ${CATALINA_PID+x} ]; then
+        CATALINA_PID=${CATALINA_BASE}/catalina.pid;
+        export CATALINA_PID;
+fi


### PR DESCRIPTION
Add comments to setenv[.bat|.sh] files. Set Xms to same value as Xmx to avoid memory resizing. Avoid to set CATALINA_PID in setenv.sh if already done (as some impact on setup when using Linux distro provided startup script).
