### PR TITLE
TR(dependencies) remove engine client and common form bonita-web

### DIFF
--- a/deploy/war-ear/pom.xml
+++ b/deploy/war-ear/pom.xml
@@ -67,11 +67,19 @@
                                         WEB-INF/lib/xpp3_min-*.jar,
                                         WEB-INF/lib/xstream-*.jar,
                                         WEB-INF/lib/ehcache*.jar,
+                                        WEB-INF/lib/httpclient*.jar,
+                                        WEB-INF/lib/httpcore*.jar,
                                         WEB-INF/lib/commons-codec*.jar,
                                         WEB-INF/lib/commons-io*.jar,
                                         WEB-INF/lib/commons-logging*.jar,
+                                        WEB-INF/lib/commons-lang3*.jar,
+                                        WEB-INF/lib/commons-beanutils*.jar,
+                                        WEB-INF/lib/commons-fileupload*.jar,
                                         WEB-INF/lib/groovy-all-*.jar,
-                                        WEB-INF/lib/spring-core-*.jar
+                                        WEB-INF/lib/spring-core-*.jar,
+                                        WEB-INF/lib/jackson-databind-*.jar,
+                                        WEB-INF/lib/jackson-core-*.jar,
+                                        WEB-INF/lib/jackson-annotations-*.jar
                                     </excludes>
                                 </artifactItem>
                             </artifactItems>

--- a/deploy/war-server/pom.xml
+++ b/deploy/war-server/pom.xml
@@ -10,6 +10,11 @@
 	<packaging>war</packaging>
 
 	<dependencies>
+        <dependency>
+            <groupId>org.bonitasoft.engine</groupId>
+            <artifactId>bonita-client</artifactId>
+            <version>${bonita.engine.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>org.bonitasoft.engine</groupId>
 			<artifactId>bonita-server</artifactId>


### PR DESCRIPTION
This PR adds engine client to bonita-distrib war-server as it was removed form bonita-web
It also excludes dependencies that are common to engine client and web from the EAR war

covers [BS-14766](https://bonitasoft.atlassian.net/browse/BS-14766)

should be merged with bonitasoft/bonita-web#272, bonitasoft/bonita-web-sp#75 and bonitasoft/bonita-distrib-sp#25