### PR TITLE
tr(ear): add bonita-client to the ear that launch selenium jboss

### DIFF
--- a/deploy/ear/pom.xml
+++ b/deploy/ear/pom.xml
@@ -30,6 +30,11 @@
 			<version>${bonita.engine.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.bonitasoft.engine</groupId>
+			<artifactId>bonita-client</artifactId>
+			<version>${bonita.engine.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>commons-dbcp</groupId>
 			<artifactId>commons-dbcp</artifactId>
 			<version>1.4</version>
@@ -72,6 +77,10 @@
 						<jarModule>
 							<groupId>org.bonitasoft.engine</groupId>
 							<artifactId>bonita-server</artifactId>
+						</jarModule>
+						<jarModule>
+							<groupId>org.bonitasoft.engine</groupId>
+							<artifactId>bonita-client</artifactId>
 						</jarModule>
 						<jarModule>
 							<groupId>org.slf4j</groupId>

--- a/deploy/war-ear/pom.xml
+++ b/deploy/war-ear/pom.xml
@@ -61,17 +61,27 @@
                                     <outputDirectory>${project.build.directory}/portal/</outputDirectory>
                                     <excludes>
                                         WEB-INF/lib/bonita-common*.jar,
+                                        WEB-INF/lib/bonita-client*.jar,
+                                        WEB-INF/lib/commons-beanutils*.jar,
+                                        WEB-INF/lib/commons-codec*.jar,
+                                        WEB-INF/lib/commons-fileupload*.jar,
+                                        WEB-INF/lib/commons-io*.jar,
+                                        WEB-INF/lib/commons-lang3*.jar,
+                                        WEB-INF/lib/commons-logging*.jar,
+                                        WEB-INF/lib/ehcache*.jar,
+                                        WEB-INF/lib/groovy-all-*.jar,
+                                        WEB-INF/lib/httpclient*.jar,
+                                        WEB-INF/lib/httpcore*.jar,
+                                        WEB-INF/lib/httpmime*.jar,
+                                        WEB-INF/lib/jackson-annotations-*.jar
+                                        WEB-INF/lib/jackson-core-*.jar,
+                                        WEB-INF/lib/jackson-databind-*.jar,
                                         WEB-INF/lib/slf4j-api*.jar,
+                                        WEB-INF/lib/spring-core-*.jar,
                                         WEB-INF/lib/stax-api*.jar,
                                         WEB-INF/lib/xmlpull-*.jar,
                                         WEB-INF/lib/xpp3_min-*.jar,
-                                        WEB-INF/lib/xstream-*.jar,
-                                        WEB-INF/lib/ehcache*.jar,
-                                        WEB-INF/lib/commons-codec*.jar,
-                                        WEB-INF/lib/commons-io*.jar,
-                                        WEB-INF/lib/commons-logging*.jar,
-                                        WEB-INF/lib/groovy-all-*.jar,
-                                        WEB-INF/lib/spring-core-*.jar
+                                        WEB-INF/lib/xstream-*.jar
                                     </excludes>
                                 </artifactItem>
                             </artifactItems>


### PR DESCRIPTION
the server need to have bonita-client.jar in order to compile bdm client
jar
also add in the ear war exclusion to avoid having duplicated
dependencies between the client war and the ear on jboss

covers [BS-14766](https://bonitasoft.atlassian.net/browse/BS-14766)