### PR TITLE
fix(case-overview) remove extra body tag

### DIFF
--- a/resources/case-autogenerated-overview/src/index.html
+++ b/resources/case-autogenerated-overview/src/index.html
@@ -115,7 +115,6 @@
       </timeline-footer>
     </timeline>
   </div>
-</body>
 
   <!-- build:js resources/js/app.js -->
   <script src="../node_modules/angular/angular.js"></script>


### PR DESCRIPTION
body tag was closed twice. ([here](https://github.com/bonitasoft/bonita-distrib/compare/fix/case-overview-extra-body-tag?expand=1#diff-c89f84d14e3316ed49c7c6fba26644f6R143))
This lead to a js script injected in html tag instead of body tag.

May fix the fact that case overview isn't displayed in tasklist dev mode