### PR TITLE
tr(stepform) launch unit test on build

### DIFF
--- a/resources/step-autogenerated-form/karma.conf.js
+++ b/resources/step-autogenerated-form/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
       'node_modules/angular-gettext/dist/angular-gettext.js',
       'node_modules/ngUpload/ng-upload.js',
       'node_modules/angular-cookies/angular-cookies.js',
-      'src/**/*.js',
+      'src/**/!(*dev-only).js',
       'test/unit/**/*Spec.js',
       // include fixtures html  in karma webserver, available at /base/dev/fixtures
       { pattern: 'dev/fixtures/**/*.html', included: false, served: true },
@@ -69,7 +69,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
+    browsers: ['PhantomJS'],
 
 
     // Continuous Integration mode

--- a/resources/step-autogenerated-form/package.json
+++ b/resources/step-autogenerated-form/package.json
@@ -3,13 +3,6 @@
   "version": "1.0.0",
   "description": "This page queries the Task contract from API and generates on the fly a form to let the user submit the expected information to the Task to be executed.",
   "main": "gulpfile.js",
-  "scripts": {
-    "dev": "gulp dev",
-    "build": "gulp default",
-    "test": "karma start --log-level dcebug --single-run",
-    "pree2e": "webdriver-manager update",
-    "e2e": "gulp e2e"
-  },
   "author": "",
   "license": "GPL",
   "devDependencies": {
@@ -32,11 +25,11 @@
     "gulp-uglify": "1.4.1",
     "gulp-usemin": "0.3.11",
     "gulp-zip": "^2.0.2",
-    "jshint-stylish": "0.4.0",
-    "karma": "0.12.37",
-    "karma-chrome-launcher": "0.1.12",
     "jasmine-core": "2.1.3",
-    "karma-jasmine": "0.3.0",
+    "jshint-stylish": "0.4.0",
+    "karma": "1.1.2",
+    "karma-jasmine": "1.0.2",
+    "karma-phantomjs-launcher": "1.0.1",
     "properties": "1.2.1",
     "protractor": "1.8.0",
     "run-sequence": "1.1.2"
@@ -49,5 +42,12 @@
     "angular-cookies": "1.3.18",
     "angular-resource": "1.3.0",
     "ngUpload": "twilson63/ngUpload#v0.5.14"
+  },
+  "scripts": {
+    "dev": "gulp dev",
+    "build": "gulp default",
+    "test": "karma start --single-run",
+    "pree2e": "webdriver-manager update",
+    "e2e": "gulp e2e"
   }
 }

--- a/resources/step-autogenerated-form/pom.xml
+++ b/resources/step-autogenerated-form/pom.xml
@@ -54,11 +54,21 @@
 						</goals>
 					</execution>
 					<execution>
+						<id>npm test</id>
+						<goals>
+							<goal>npm</goal>
+						</goals>
+						<phase>test</phase>
+						<configuration>
+							<arguments>run test</arguments>
+						</configuration>
+					</execution>
+					<execution>
 						<id>npm build</id>
 						<goals>
 							<goal>npm</goal>
 						</goals>
-						<phase>generate-resources</phase>
+						<phase>prepare-package</phase>
 						<configuration>
 							<arguments>run build</arguments>
 						</configuration>


### PR DESCRIPTION
- Use phantonjs as test browser (instead of chrome)
- Update karma and karma-jasmine versions
- Ignore *dev-only files while launching tests
- Launch unit test while building step-autogenerated-form

:warning: **TESTS DO NOT PASS**

@abirembaut would you mind fixing the tests [step-autogenerated-form](https://github.com/bonitasoft/bonita-distrib/blob/master/resources/step-autogenerated-form/test/unit/appSpec.js#L106) and [process-autogenerated-form](https://github.com/bonitasoft/bonita-distrib/blob/master/resources/process-autogenerated-form/test/unit/appSpec.js#L126) on master branch ? We can merge this one once tests pass and dev branch is rebased on master